### PR TITLE
Fix logs and authorizations

### DIFF
--- a/src/Jobs/CheckIfBotIsReal.php
+++ b/src/Jobs/CheckIfBotIsReal.php
@@ -16,6 +16,7 @@ class CheckIfBotIsReal implements ShouldQueue
 
     protected $client;
     protected $options;
+    protected $allowedBots;
 
 
     /**
@@ -52,7 +53,7 @@ class CheckIfBotIsReal implements ShouldQueue
         }
 
         // Lets remove from the pending list
-        Redis::srem($this->options->pending_bots_key, $this->client->ip);
+        Redis::srem($this->options->pending_bot_list_key, $this->client->ip);
         if ($this->isValid($found_bot_key)) {
             Redis::sadd($this->options->whitelist_key, $this->client->ip);
 

--- a/src/Middleware/BlockBots.php
+++ b/src/Middleware/BlockBots.php
@@ -49,7 +49,9 @@ class BlockBots extends AbstractBlockBots
     protected function notAllowed()
     {
         if ($this->options->log) {
-            $this->logDisallowance();
+            if (!$this->options->log_only_guest || Auth::guest()) {
+                $this->logDisallowance();
+            }
         }
 
         if (Auth::check() && $this->isTheFirstOverflow()) {

--- a/src/config/block-bots.php
+++ b/src/config/block-bots.php
@@ -54,6 +54,7 @@ return [
      */
 
     'log' => env('BLOCK_BOTS_LOG_ENABLED', env('BLOCK_BOTS_LOG_BLOCKED_REQUESTS', true)),
+    'log_only_guest' => env('BLOCK_BOTS_LOG_ONLY_GUEST', true),
 
     /*
      * The list of allowed user-agents. The value of the key should be a keyword in hostname or * for enable to everyone


### PR DESCRIPTION
- Fixes pending list access, it was using a wrong key;
- Adds the limit information in the log message;
- Fixes guest output. Now, when access limit exceeded, guest users are tested with bot control. Before change, bot control was being unreachable;
- Fixes access counter. It was starting at 2, now it starts at 1;
- Adds 'BLOCK_BOTS_LOG_ONLY_GUEST' enviroment.
