### PR TITLE
add console commands to list [hits, notified], event BotBlockedEvent

### DIFF
--- a/src/BlockBotsServiceProvider.php
+++ b/src/BlockBotsServiceProvider.php
@@ -3,8 +3,10 @@
 namespace Potelo\LaravelBlockBots;
 
 use Illuminate\Support\ServiceProvider;
-use Potelo\LaravelBlockBots\Commands\ListWhitelist;
 use Potelo\LaravelBlockBots\Commands\ClearWhitelist;
+use Potelo\LaravelBlockBots\Commands\ListWhitelist;
+use Potelo\LaravelBlockBots\Commands\ListHits;
+use Potelo\LaravelBlockBots\Commands\ListNotified;
 
 class BlockBotsServiceProvider extends ServiceProvider
 {
@@ -18,8 +20,10 @@ class BlockBotsServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->commands([
-                ListWhitelist::class,
                 ClearWhitelist::class,
+                ListWhitelist::class,
+                ListHits::class,
+                ListNotified::class,
             ]);
         }
 

--- a/src/Commands/ListHits.php
+++ b/src/Commands/ListHits.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Potelo\LaravelBlockBots\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Redis;
+use Potelo\LaravelBlockBots\Contracts\Configuration;
+
+class ListHits extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'block-bots:list-hits';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show the list of IPs with hits count';
+
+    /**
+     * @var \Potelo\LaravelBlockBots\Contracts\Configuration
+     */
+    private $options;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->options = new Configuration();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->info("List of IPs hits:");
+        
+        $keys = Redis::keys('block_bot:hits*');
+        
+        foreach ($keys as $key) {
+            $key = str($key)->afterLast(':');
+            $this->info($key . " : " . Redis::get("block_bot:hits:{$key}"));
+        }
+    }
+}

--- a/src/Commands/ListNotified.php
+++ b/src/Commands/ListNotified.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Potelo\LaravelBlockBots\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Redis;
+use Potelo\LaravelBlockBots\Contracts\Configuration;
+
+class ListNotified extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'block-bots:list-notified';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show the list of notified IPs with notified count';
+
+    /**
+     * @var \Potelo\LaravelBlockBots\Contracts\Configuration
+     */
+    private $options;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->options = new Configuration();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->info("List of notified IPs with notified count:");
+        
+        $keys = Redis::keys('block_bot:notified*');
+        
+        foreach ($keys as $key) {
+            $key = str($key)->afterLast(':');
+            $this->info($key . " : " . Redis::get("block_bot:notified:{$key}"));
+        }
+    }
+}

--- a/src/Contracts/Client.php
+++ b/src/Contracts/Client.php
@@ -26,7 +26,7 @@ class Client
         $this->ip = $request->getClientIp();
         $this->id = Auth::check() ? Auth::id() : $this->ip;
         $this->userAgent = $request->header('User-Agent');
-        $this->key = "block_bot:{$this->id}";
+        $this->key = "block_bot:hits:{$this->id}";
         $this->logKey = "block_bot:notified:{$this->ip}";
         $this->url = substr($request->fullUrl(), strlen($request->getScheme() . "://"));
         $this->options = new Configuration();

--- a/src/Events/BotBlockedEvent.php
+++ b/src/Events/BotBlockedEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Potelo\LaravelBlockBots\Events;
+
+use Carbon\Carbon;
+use Illuminate\Queue\SerializesModels;
+
+class BotBlockedEvent
+{
+    use SerializesModels;
+
+    public $ip;
+
+    /** @var integer */
+    public $number_of_hits;
+
+    /** @var Carbon */
+    public $block_date;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param $ip
+     * @param  integer  $number_of_hits
+     * @param  Carbon  $block_date
+     *
+     * @return void
+     */
+    public function __construct($ip, $number_of_hits, $block_date)
+    {
+        $this->ip = $ip;
+        $this->number_of_hits = $number_of_hits;
+        $this->block_date = $block_date;
+    }
+}

--- a/src/Middleware/BlockBots.php
+++ b/src/Middleware/BlockBots.php
@@ -10,7 +10,7 @@ use Potelo\LaravelBlockBots\Jobs\CheckIfBotIsReal;
 use Potelo\LaravelBlockBots\Events\UserBlockedEvent;
 use Potelo\LaravelBlockBots\Jobs\ProcessLogWithIpInfo;
 use Potelo\LaravelBlockBots\Abstracts\AbstractBlockBots;
-
+use Potelo\LaravelBlockBots\Events\BotBlockedEvent;
 
 class BlockBots extends AbstractBlockBots
 {
@@ -55,6 +55,9 @@ class BlockBots extends AbstractBlockBots
             event(new UserBlockedEvent(Auth::user(), $this->hits, Carbon::now()));
         }
 
+        if (Auth::guest() && $this->isTheFirstOverflow()) {
+            event(new BotBlockedEvent($this->client->ip, $this->hits, Carbon::now()));
+        }
 
         if ($this->request->expectsJson()) {
             return response()->json($this->options->json_response, 429);


### PR DESCRIPTION
```
php artisan block-bots:list-hits
php artisan block-bots:list-notified
```

I had to modify the key attribute 
https://github.com/Potelo/laravel-block-bots/blob/43f552d0b0770a0b57fc06f1018db93dab28dfbc/src/Contracts/Client.php#L29
and adding prefix 
```php 
$this->key = "block_bot:hits:{$this->id}"
```
so I can use this prefix in commands like so
```php
$keys = Redis::keys('block_bot:hits*');
```

Also I've added an event BotBlockedEvent
